### PR TITLE
fix: pin final image to alpine:3.12

### DIFF
--- a/scripts/Dockerfile.alpine
+++ b/scripts/Dockerfile.alpine
@@ -26,7 +26,7 @@ RUN /device-coap/scripts/build.sh
 # Next, copy the binaries and headers from the build image above to the final
 # runtime image.
 
-FROM ${BASE}
+FROM alpine:3.12
 
 WORKDIR /
 


### PR DESCRIPTION
Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#15 

## What is the new behavior?
Final image is pinned to alpine:3.12

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information