### PR TITLE
fix: testing lts builds

### DIFF
--- a/scripts/Dockerfile.alpine-base
+++ b/scripts/Dockerfile.alpine-base
@@ -12,7 +12,6 @@ RUN apk add --update --no-cache build-base git gcc cmake make linux-headers yaml
 
 COPY scripts /device-coap/scripts
 COPY src /device-coap/src/
-COPY VERSION /device-coap
 RUN mkdir -p /device-coap/build
 
 WORKDIR /device-coap

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,6 +9,8 @@ cd $ROOT
 
 # Cmake release build
 
+echo "This is the lts-fix branch"
+
 mkdir -p $ROOT/build/release
 cd $ROOT/build/release
 cmake -DCMAKE_BUILD_TYPE=Release $ROOT/src/c


### PR DESCRIPTION
DO NOT MERGE. Testing mock C build for LTS releases.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-coap-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-coap-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->