### PR TITLE
feat: Enhancement of CoAP server device service with CoAP client functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Also see my Zephyr based [edgex-coap-peer](https://github.com/kb2ma/edgex-coap-p
 
 Also see my RIOT based [riot-edgex-coap-client](https://github.com/kb2ma/riot-edgex-coap-client) repository for a more realistic CoAP client. The client posts a temperature measurement from a sensor every 60 seconds to `/a1r/d1/float`.
 
-### Testing/Simulation for CoAP Client
+## Testing/Simulation for CoAP Client
 
 You can use simulated data to test the CoAP client functionality of this device service using libcoap server. Resources must be handled properly in the coap-server to test CoAP client. The examples below are organized by the ED_SecurityMode defined in devices.json.
 

--- a/res/devices/d1.json
+++ b/res/devices/d1.json
@@ -1,7 +1,0 @@
-{
-  "name": "d1",
-  "profileName": "example-datatype",
-  "description": "Example generic data type device",
-  "labels": [ "coap", "rest" ],
-  "protocols": { "other": { } }
-}

--- a/res/devices/devices.json
+++ b/res/devices/devices.json
@@ -1,0 +1,64 @@
+[
+  {
+    "name": "d1",
+    "profileName": "example-datatype",
+    "description": "Example generic data type device",
+    "labels": [ "coap", "rest" ],
+    "protocols": { "other": { } }
+  },
+  {
+    "name": "d2",
+    "profileName": "example-datatype",
+    "description": "Example generic data type device",
+    "protocols":
+    {
+       "COAP": 
+       {
+         "ED_ADDR": "127.0.0.1",
+         "ED_SecurityMode": "NoSec",
+      	 "ED_PskKey": "hello123"
+       }
+    },
+    "autoEvents":
+    [   
+      { "sourceName": "int", "onChange": false, "interval": "30s" }
+    ]   
+  },
+  {
+    "name": "d3",
+    "profileName": "example-datatype",
+    "description": "Example generic data type device",
+    "protocols":
+    {
+       "COAP": 
+       {
+         "ED_ADDR": "127.0.0.1",
+         "ED_SecurityMode": "NoSec",
+      	 "ED_PskKey": "hello123"
+       }
+    },
+    "autoEvents":
+    [   
+      { "sourceName": "float", "onChange": false, "interval": "30s" }
+    ]   
+  },
+  {
+    "name": "d4",
+    "profileName": "example-datatype",
+    "description": "Example generic data type device",
+    "protocols":
+    {
+       "COAP": 
+       {
+         "ED_ADDR": "127.0.0.1",
+         "ED_SecurityMode": "NoSec",
+      	 "ED_PskKey": "hello123"
+       }
+    },
+    "autoEvents":
+    [   
+      { "sourceName": "json", "onChange": false, "interval": "30s" }
+    ]   
+  }
+]
+

--- a/res/profiles/example-datatype.json
+++ b/res/profiles/example-datatype.json
@@ -8,17 +8,44 @@
     {
       "name": "float",
       "description": "Float64 value",
-      "properties": { "valueType": "Float64", "readWrite": "R" }
+      "properties": { "valueType": "Float64", "readWrite": "RW" }
     },
     {
       "name": "int",
       "description": "Int32 value",
-      "properties": { "valueType": "Int32", "readWrite": "R" }
+      "properties": { "valueType": "Int32", "readWrite": "RW" }
     },
     {
       "name": "json",
       "description": "JSON message",
-      "properties": { "valueType": "String", "readWrite": "R" }
+      "properties": { "valueType": "String", "readWrite": "RW" }
     }
+  ],
+  "deviceCommands":
+  [
+    {
+      "name": "int",
+      "readWrite": "RW",
+      "resourceOperations":
+      [
+        { "deviceResource": "int" }
+      ]
+    },
+    {
+      "name": "json",
+      "readWrite": "RW",
+      "resourceOperations":
+      [
+        { "deviceResource": "json" }
+      ]
+    },
+    {   
+      "name": "float",
+      "readWrite": "RW",
+      "resourceOperations":
+      [   
+        { "deviceResource": "float" }
+      ]   
+    } 
   ]
 }

--- a/res/profiles/example-datatype.json
+++ b/res/profiles/example-datatype.json
@@ -24,28 +24,14 @@
   "deviceCommands":
   [
     {
-      "name": "int",
+      "name": "cmd",
       "readWrite": "RW",
       "resourceOperations":
       [
-        { "deviceResource": "int" }
-      ]
-    },
-    {
-      "name": "json",
-      "readWrite": "RW",
-      "resourceOperations":
-      [
+        { "deviceResource": "int" },
+        { "deviceResource": "float" },
         { "deviceResource": "json" }
       ]
-    },
-    {   
-      "name": "float",
-      "readWrite": "RW",
-      "resourceOperations":
-      [   
-        { "deviceResource": "float" }
-      ]   
-    } 
+    }
   ]
 }

--- a/src/c/coap-client.c
+++ b/src/c/coap-client.c
@@ -1,0 +1,425 @@
+/* CoAP cli.t .r thread device service
+ *
+ * Copyright (c) 2021
+ * Sudhamani
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "coap-client.h"
+
+#include <coap2/coap.h>
+#include <errno.h>
+#include <float.h>
+#include <netdb.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "coap-util.h"
+#include "device-coap.h"
+#include "edgex/devices.h"
+
+static coap_driver *sdk_ctx;
+/* controls input loop */
+extern volatile sig_atomic_t quit;
+iot_data_t *coap_resp_data = NULL;
+static bool coap_resp_rcvd;
+typedef struct {
+  char end_dev_name[8];
+  char end_dev_addr[144];
+  char end_dev_uri_path[32];
+  coap_security_mode_t security_mode; /**< CoAP transport security mode */
+  char psk_key[16];
+} end_dev_params;
+
+end_dev_params end_dev_params_instance;  // end devices data needs to be
+                                         // stored from configuration
+
+/*
+ * Get End device protocol property, expect 3 arguments:
+ * @param[in] protocol structure
+ * @param[in] protocol name
+ * @param[in] property name
+ * @return property value
+ */
+static const char *GetEndDeviceProtocolProperty(
+    const devsdk_protocols *protocols, char *protocol_name, char *name) {
+  sdk_ctx = impl;
+  iot_data_t *exception[] = {NULL};
+  const iot_data_t *props =
+      devsdk_protocols_properties(protocols, protocol_name);
+  if (props == NULL) {
+    *exception = iot_data_alloc_string("No COAP protocol in device address",
+                                       IOT_DATA_REF);
+    return NULL;
+  }
+  const char *property_val = iot_data_string_map_get_string(props, name);
+  if (property_val == NULL) {
+    *exception = iot_data_alloc_string("property in device address missing",
+                                       IOT_DATA_REF);
+    return NULL;
+  }
+
+  return property_val;
+}
+
+/*
+ * Get End device configuration and update it to end_dev_params_instance
+ * structure
+ * @param[in] device name
+ * @return true if configuration is updated successfully to
+ * end_dev_params_instance
+ */
+
+bool GetEndDeviceConfig(char *dev_name) {
+  const char *params_ptr;
+
+  edgex_device *device = NULL;
+  bool res = false;
+  sdk_ctx = impl;
+
+  iot_log_info(sdk_ctx->lc, "COAP: Auto events debug: %s", dev_name);
+  if (!(device = edgex_get_device_byname(sdk_ctx->service, dev_name))) {
+    iot_log_info(sdk_ctx->lc, "COAP:device not found: %s", dev_name);
+  }
+  iot_log_info(sdk_ctx->lc, "COAP:device found: %s", dev_name);
+  res = true;
+
+  iot_log_info(sdk_ctx->lc, "COAP:Get protocol property");
+  const devsdk_protocols *protocols = device->protocols;
+  if (protocols == NULL) {
+    iot_log_error(sdk_ctx->lc, "COAP:protocols NULL");
+    res = false;
+  }
+
+  if (res) {
+    iot_log_info(sdk_ctx->lc, "COAP:Get COAP protocol property");
+    params_ptr = GetEndDeviceProtocolProperty(protocols, "COAP", "ED_ADDR");
+    if (params_ptr == NULL) {
+      return false;
+    }
+    strcpy(end_dev_params_instance.end_dev_addr, params_ptr);
+    iot_log_info(sdk_ctx->lc, "COAP:End dev addr ptr= %s",
+                 end_dev_params_instance.end_dev_addr);
+
+    params_ptr =
+        GetEndDeviceProtocolProperty(protocols, "COAP", "ED_SecurityMode");
+    if (params_ptr == NULL) {
+      return false;
+    }
+    iot_log_info(sdk_ctx->lc, "COAP: End dev SecMode ptr= %s", params_ptr);
+    end_dev_params_instance.security_mode = find_security_mode(params_ptr);
+
+    switch (end_dev_params_instance.security_mode) {
+      case SECURITY_MODE_UNKNOWN: {
+        iot_log_error(sdk_ctx->lc, "COAP:ED Unknown security mode");
+        return false;
+      }
+      case SECURITY_MODE_PSK: {
+        params_ptr =
+            GetEndDeviceProtocolProperty(protocols, "COAP", "ED_PskKey");
+        if (params_ptr == NULL) {
+          return false;
+        }
+        iot_log_info(sdk_ctx->lc, "COAP:End dev PskKey ptr= %s", params_ptr);
+        if (strlen(params_ptr)) {
+          strcpy(end_dev_params_instance.psk_key, params_ptr);
+          iot_log_info(sdk_ctx->lc, "COAP:PSK key len %u",
+                       strlen(end_dev_params_instance.psk_key));
+        } else {
+          iot_log_error(sdk_ctx->lc, "COAP:ED PSK key not in configuration");
+          return false;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+  } else {
+    edgex_free_device(sdk_ctx->service, device);
+  }
+  return res;
+}
+/*
+ * coap get request callback handler. Get coap data from the coap pdu and update
+ * it to coap_resp_data_buf
+ */
+static void message_handler(struct coap_context_t *ctx, coap_session_t *session,
+                            coap_pdu_t *sent, coap_pdu_t *received,
+                            const coap_tid_t id) {
+  edgex_device *device = NULL;
+  edgex_deviceresource *resource = NULL;
+  uint8_t *data = NULL;
+  size_t len = 0;
+  sdk_ctx = impl;
+  coap_resp_data = NULL;
+  coap_show_pdu(LOG_WARNING, received);
+  switch (sent->code) {
+    case COAP_REQUEST_GET: {
+      /* Validate URI, expect 3 segments: /a1r/{device-name}/{resource-name} */
+      if (!parse_path(sent, &device, &resource)) {
+        goto finish;
+      }
+
+      if (!coap_get_data(received, &len, &data)) {
+        iot_log_info(sdk_ctx->lc, "COAP:invalid data of len %u", len);
+      }
+
+      iot_log_info(sdk_ctx->lc, "COAP: coap device resource type %d",
+                   resource->properties->type);
+
+      /* Validate and read payload. Content format from option must be
+       * acceptable for resource value type. */
+
+      switch (resource->properties->type) {
+        case Edgex_Float64:
+          /* data conversion requires a null terminated string */
+          coap_resp_data = read_data_float64(data, len);
+          iot_log_info(sdk_ctx->lc, "COAP:coap float data=%s, len = %d", data,
+                       len);
+          break;
+
+        case Edgex_Int32:
+          iot_log_info(sdk_ctx->lc, "COAP:coap int32 data=%s, len = %d", data,
+                       len);
+          coap_resp_data = read_data_int32(data, len);
+          break;
+
+        case Edgex_String:
+          coap_resp_data = read_data_string(data, len);
+          iot_log_info(sdk_ctx->lc, "COAP:coap json data=%s, len = %d", data,
+                       len);
+          break;
+
+        default:
+          iot_log_error(sdk_ctx->lc, "COAP:unsupported resource type %d",
+                        resource->properties->type);
+          goto finish;
+      }
+      break;
+    }
+    case COAP_REQUEST_PUT:
+      break;
+    default:
+      break;
+  }
+
+finish:
+  edgex_free_device(sdk_ctx->service, device);
+  coap_resp_rcvd = true;
+}
+/*
+waits for coap response for CON request from end device
+*/
+static void WaitForCoapResponseFromEndDevice(coap_context_t *ctx,
+                                             coap_session_t *session) {
+  while (1) {
+    coap_io_process(ctx, COAP_IO_WAIT);
+    if (coap_resp_rcvd == true || quit == 1) {
+      coap_session_release(session);
+      coap_free_context(ctx);
+      coap_resp_rcvd = false;
+      break;
+    }
+  }
+}
+
+int CoapSendCommandToEndDevice(uint8_t *data, size_t len, char *dev_name,
+                               char *resource_name) {
+  coap_context_t *ctx = NULL;
+  coap_session_t *session = NULL;
+  coap_address_t dst;
+  coap_pdu_t *pdu = NULL;
+  sdk_ctx = impl;
+  int result = EXIT_FAILURE;
+  uint8_t *post_data = data;
+  char uri[COAP_URI_MAXLEN + 1] = {0};
+
+  coap_startup();
+  coap_proto_t proto = COAP_PROTO_UDP;
+  char *port = "5683";
+
+  if (end_dev_params_instance.security_mode != SECURITY_MODE_NOSEC) {
+    proto = COAP_PROTO_DTLS;
+    port = "5684";
+  }
+
+  if (resolve_address(end_dev_params_instance.end_dev_addr, port, &dst) < 0) {
+    coap_log(LOG_CRIT, "COAP:failed to resolve address\n");
+    return result;
+  }
+  iot_log_info(sdk_ctx->lc, "COAP: End dev addr = %s",
+               end_dev_params_instance.end_dev_addr);
+
+  iot_log_info(sdk_ctx->lc, "COAP: Data = %d, Len = %d", *post_data, len);
+  /* create CoAP context and a client session */
+  ctx = coap_new_context(NULL);
+  if (ctx == NULL) {
+    iot_log_error(sdk_ctx->lc, "COAP:coap new context creation failed\n");
+    return result;
+  }
+  if (end_dev_params_instance.security_mode == SECURITY_MODE_PSK) {
+    iot_log_info(sdk_ctx->lc, "COAP-client:ED psk key = %s, len=%d",
+                 (uint8_t *)end_dev_params_instance.psk_key,
+                 strlen(end_dev_params_instance.psk_key));
+    if (!ctx || !(session = coap_new_client_session_psk(
+                      ctx, NULL, &dst, proto, "r17",
+                      (uint8_t *)(end_dev_params_instance.psk_key),
+                      strlen(end_dev_params_instance.psk_key)))) {
+      iot_log_error(sdk_ctx->lc, "COAP:cannot initialize PSK");
+      return result;
+    }
+  } else {
+    if (!ctx || !(session = coap_new_client_session(ctx, NULL, &dst, proto))) {
+      coap_log(LOG_EMERG, "COAP:cannot create client session\n");
+      return result;
+    }
+  }
+  coap_register_response_handler(ctx, message_handler);
+
+  /* construct CoAP message */
+  pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_PUT,
+                      coap_new_message_id(session) /* message id */,
+                      coap_session_max_pdu_size(session));
+  if (!pdu) {
+    coap_log(LOG_EMERG, "COAP:cannot create PDU\n");
+    return result;
+  }
+
+  sprintf(uri, "/a1r/%s/%s", dev_name, resource_name);
+  int res;
+#define BUFSIZE 40
+  unsigned char _buf[BUFSIZE] = {0};
+  unsigned char *buf = _buf;
+  size_t buflen;
+  buflen = BUFSIZE;
+  res = coap_split_path((const uint8_t *)uri, strlen(uri), buf, &buflen);
+
+  while (res--) {
+    coap_add_option(pdu, COAP_OPTION_URI_PATH, coap_opt_length(buf),
+                    coap_opt_value(buf));
+    iot_log_debug(sdk_ctx->lc, "uri.path_val = %s\n", coap_opt_value(buf));
+
+    buf += coap_opt_size(buf);
+  }
+
+  //  result = coap_add_option(pdu, COAP_OPTION_URI_PATH, strlen(uri),
+  //                           (const uint8_t *)(uri));
+  if (result <= 0) {  // size
+    result = EXIT_FAILURE;
+    return result;
+  }
+  if (!coap_add_data(pdu, len, (unsigned char *)post_data)) {
+    return result;
+  }
+  coap_show_pdu(LOG_WARNING, pdu);
+
+  /* and send the PDU */
+  if (coap_send(session, pdu) == COAP_INVALID_TID) {
+    return result;
+  }
+  WaitForCoapResponseFromEndDevice(ctx, session);
+  result = EXIT_SUCCESS;
+  return result;
+}
+/*
+send coap get request to end device. waits for the response form end device.
+*/
+int CoapGetRequestToEndDevice(char *dev_name, char *resource_name) {
+  coap_context_t *ctx = NULL;
+  coap_session_t *session = NULL;
+  coap_address_t dst;
+  coap_pdu_t *pdu = NULL;
+  sdk_ctx = impl;
+  int result = EXIT_FAILURE;
+  char uri[COAP_URI_MAXLEN + 1] = {0};
+
+  coap_startup();
+
+  coap_proto_t proto = COAP_PROTO_UDP;
+  char *port = "5683";
+
+  if (end_dev_params_instance.security_mode != SECURITY_MODE_NOSEC) {
+    proto = COAP_PROTO_DTLS;
+    port = "5684";
+  }
+
+  if (resolve_address(end_dev_params_instance.end_dev_addr, port, &dst) < 0) {
+    coap_log(LOG_CRIT, "COAP:failed to resolve address\n");
+    return result;
+  }
+  iot_log_info(sdk_ctx->lc, "COAP: End dev addr = %s",
+               end_dev_params_instance.end_dev_addr);
+
+  /* create CoAP context and a client session */
+  ctx = coap_new_context(NULL);
+  if (ctx == NULL) {
+    iot_log_error(sdk_ctx->lc, "COAP:coap new context creation failed\n");
+    return result;
+  }
+  if (end_dev_params_instance.security_mode == SECURITY_MODE_PSK) {
+    iot_log_info(sdk_ctx->lc, "COAP-client:ED psk key = %s, len=%d",
+                 (uint8_t *)end_dev_params_instance.psk_key,
+                 strlen(end_dev_params_instance.psk_key));
+    if (!ctx || !(session = coap_new_client_session_psk(
+                      ctx, NULL, &dst, proto, "r17",
+                      (uint8_t *)(end_dev_params_instance.psk_key),
+                      strlen(end_dev_params_instance.psk_key)))) {
+      iot_log_error(sdk_ctx->lc, "COAP:cannot initialize PSK");
+      return result;
+    }
+  } else {
+    if (!ctx || !(session = coap_new_client_session(ctx, NULL, &dst, proto))) {
+      coap_log(LOG_EMERG, "COAP:cannot create client session\n");
+      return result;
+    }
+  }
+  coap_register_response_handler(ctx, message_handler);
+
+  /* construct CoAP message */
+  pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_GET,
+                      coap_new_message_id(session) /* message id */,
+                      coap_session_max_pdu_size(session));
+  if (!pdu) {
+    coap_log(LOG_EMERG, "COAP:cannot create PDU\n");
+    return result;
+  }
+
+  sprintf(uri, "/a1r/%s/%s", dev_name, resource_name);
+  int res;
+#define BUFSIZE 40
+  unsigned char _buf[BUFSIZE] = {0};
+  unsigned char *buf = _buf;
+  size_t buflen;
+  buflen = BUFSIZE;
+  res = coap_split_path((const uint8_t *)uri, strlen(uri), buf, &buflen);
+  while (res--) {
+    result = coap_add_option(pdu, COAP_OPTION_URI_PATH, coap_opt_length(buf),
+                             coap_opt_value(buf));
+    iot_log_debug(sdk_ctx->lc, "uri.path_val = %s\n", coap_opt_value(buf));
+
+    buf += coap_opt_size(buf);
+  }
+  if (result <= 0) {  // size
+    result = EXIT_FAILURE;
+    return result;
+  }
+
+  coap_show_pdu(LOG_WARNING, pdu);
+  /* and send the PDU */
+  if (coap_send(session, pdu) == COAP_INVALID_TID) {
+    coap_log(LOG_EMERG, "COAP:coap_send cannot send pdu\n");
+    return result;
+  }
+  WaitForCoapResponseFromEndDevice(ctx, session);
+  result = EXIT_SUCCESS;
+  return result;
+}

--- a/src/c/coap-client.c
+++ b/src/c/coap-client.c
@@ -26,131 +26,84 @@
 #include "device-coap.h"
 #include "edgex/devices.h"
 
-static coap_driver *sdk_ctx;
 /* controls input loop */
 extern volatile sig_atomic_t quit;
 iot_data_t *coap_resp_data = NULL;
-static bool coap_resp_rcvd;
-typedef struct {
-  char end_dev_name[8];
-  char end_dev_addr[144];
-  char end_dev_uri_path[32];
-  coap_security_mode_t security_mode; /**< CoAP transport security mode */
-  char psk_key[16];
-} end_dev_params;
-
-end_dev_params end_dev_params_instance;  // end devices data needs to be
-                                         // stored from configuration
+static bool coap_resp_rcvd = false;
 
 /*
- * Get End device protocol property, expect 3 arguments:
+ * Get End device protocol property, expect 5 arguments:
  * @param[in] protocol structure
  * @param[in] protocol name
- * @param[in] property name
- * @return property value
+ * @param[in] exception ptr
+ * @param[in] end device structure variable address to store protocol properties
+ * @param[in] coap driver pointer
+ * @return success or fail
  */
-static const char *GetEndDeviceProtocolProperty(
-    const devsdk_protocols *protocols, char *protocol_name, char *name) {
-  sdk_ctx = impl;
-  iot_data_t *exception[] = {NULL};
+bool GetEndDeviceProtocolProperties(const devsdk_protocols *protocols,
+                                    char *protocol_name, iot_data_t **exception,
+                                    end_dev_params *end_dev_params_ptr,
+                                    coap_driver *driver) {
+  coap_driver *sdk_ctx = (coap_driver *)driver;
   const iot_data_t *props =
       devsdk_protocols_properties(protocols, protocol_name);
   if (props == NULL) {
     *exception = iot_data_alloc_string("No COAP protocol in device address",
                                        IOT_DATA_REF);
-    return NULL;
+    return false;
   }
-  const char *property_val = iot_data_string_map_get_string(props, name);
-  if (property_val == NULL) {
+  const char *params_ptr = iot_data_string_map_get_string(props, "ED_ADDR");
+  if (params_ptr == NULL) {
     *exception = iot_data_alloc_string("property in device address missing",
                                        IOT_DATA_REF);
-    return NULL;
+    return false;
   }
+  strcpy(end_dev_params_ptr->end_dev_addr, params_ptr);
+  iot_log_debug(sdk_ctx->lc, "COAP:End dev addr ptr= %s",
+                end_dev_params_ptr->end_dev_addr);
 
-  return property_val;
-}
-
-/*
- * Get End device configuration and update it to end_dev_params_instance
- * structure
- * @param[in] device name
- * @return true if configuration is updated successfully to
- * end_dev_params_instance
- */
-
-bool GetEndDeviceConfig(char *dev_name) {
-  const char *params_ptr;
-
-  edgex_device *device = NULL;
-  bool res = false;
-  sdk_ctx = impl;
-
-  iot_log_info(sdk_ctx->lc, "COAP: Auto events debug: %s", dev_name);
-  if (!(device = edgex_get_device_byname(sdk_ctx->service, dev_name))) {
-    iot_log_info(sdk_ctx->lc, "COAP:device not found: %s", dev_name);
+  params_ptr = iot_data_string_map_get_string(props, "ED_SecurityMode");
+  if (params_ptr == NULL) {
+    *exception = iot_data_alloc_string("property in device address missing",
+                                       IOT_DATA_REF);
+    return false;
   }
-  iot_log_info(sdk_ctx->lc, "COAP:device found: %s", dev_name);
-  res = true;
+  iot_log_debug(sdk_ctx->lc, "COAP: End dev SecMode ptr= %s", params_ptr);
+  end_dev_params_ptr->security_mode = find_security_mode(params_ptr);
 
-  iot_log_info(sdk_ctx->lc, "COAP:Get protocol property");
-  const devsdk_protocols *protocols = device->protocols;
-  if (protocols == NULL) {
-    iot_log_error(sdk_ctx->lc, "COAP:protocols NULL");
-    res = false;
-  }
-
-  if (res) {
-    iot_log_info(sdk_ctx->lc, "COAP:Get COAP protocol property");
-    params_ptr = GetEndDeviceProtocolProperty(protocols, "COAP", "ED_ADDR");
-    if (params_ptr == NULL) {
+  switch (end_dev_params_ptr->security_mode) {
+    case SECURITY_MODE_UNKNOWN: {
+      iot_log_error(sdk_ctx->lc, "COAP:ED Unknown security mode");
       return false;
     }
-    strcpy(end_dev_params_instance.end_dev_addr, params_ptr);
-    iot_log_info(sdk_ctx->lc, "COAP:End dev addr ptr= %s",
-                 end_dev_params_instance.end_dev_addr);
-
-    params_ptr =
-        GetEndDeviceProtocolProperty(protocols, "COAP", "ED_SecurityMode");
-    if (params_ptr == NULL) {
-      return false;
-    }
-    iot_log_info(sdk_ctx->lc, "COAP: End dev SecMode ptr= %s", params_ptr);
-    end_dev_params_instance.security_mode = find_security_mode(params_ptr);
-
-    switch (end_dev_params_instance.security_mode) {
-      case SECURITY_MODE_UNKNOWN: {
-        iot_log_error(sdk_ctx->lc, "COAP:ED Unknown security mode");
+    case SECURITY_MODE_PSK: {
+      params_ptr = iot_data_string_map_get_string(props, "ED_PskKey");
+      if (params_ptr == NULL) {
+        *exception = iot_data_alloc_string("property in device address missing",
+                                           IOT_DATA_REF);
         return false;
       }
-      case SECURITY_MODE_PSK: {
-        params_ptr =
-            GetEndDeviceProtocolProperty(protocols, "COAP", "ED_PskKey");
-        if (params_ptr == NULL) {
-          return false;
-        }
-        iot_log_info(sdk_ctx->lc, "COAP:End dev PskKey ptr= %s", params_ptr);
-        if (strlen(params_ptr)) {
-          strcpy(end_dev_params_instance.psk_key, params_ptr);
-          iot_log_info(sdk_ctx->lc, "COAP:PSK key len %u",
-                       strlen(end_dev_params_instance.psk_key));
-        } else {
-          iot_log_error(sdk_ctx->lc, "COAP:ED PSK key not in configuration");
-          return false;
-        }
-        break;
+      iot_log_debug(sdk_ctx->lc, "COAP:End dev PskKey ptr= %s", params_ptr);
+      if (strlen(params_ptr)) {
+        strcpy(end_dev_params_ptr->psk_key, params_ptr);
+        iot_log_debug(sdk_ctx->lc, "COAP:PSK key len %u",
+                      strlen(end_dev_params_ptr->psk_key));
+      } else {
+        iot_log_error(sdk_ctx->lc, "COAP:ED PSK key not in configuration");
+        return false;
       }
-      default:
-        break;
+      break;
     }
-
-  } else {
-    edgex_free_device(sdk_ctx->service, device);
+    case SECURITY_MODE_NOSEC:
+      break;
+    default:
+      break;
   }
-  return res;
+  return true;
 }
 /*
  * coap get request callback handler. Get coap data from the coap pdu and update
- * it to coap_resp_data_buf
+ * it to coap_resp_data
  */
 static void message_handler(struct coap_context_t *ctx, coap_session_t *session,
                             coap_pdu_t *sent, coap_pdu_t *received,
@@ -159,7 +112,7 @@ static void message_handler(struct coap_context_t *ctx, coap_session_t *session,
   edgex_deviceresource *resource = NULL;
   uint8_t *data = NULL;
   size_t len = 0;
-  sdk_ctx = impl;
+  coap_driver *sdk_ctx = (coap_driver *)impl;
   coap_resp_data = NULL;
   coap_show_pdu(LOG_WARNING, received);
   switch (sent->code) {
@@ -170,11 +123,11 @@ static void message_handler(struct coap_context_t *ctx, coap_session_t *session,
       }
 
       if (!coap_get_data(received, &len, &data)) {
-        iot_log_info(sdk_ctx->lc, "COAP:invalid data of len %u", len);
+        iot_log_error(sdk_ctx->lc, "COAP:invalid data of len %u", len);
       }
 
-      iot_log_info(sdk_ctx->lc, "COAP: coap device resource type %d",
-                   resource->properties->type);
+      iot_log_debug(sdk_ctx->lc, "COAP: coap device resource type %d",
+                    resource->properties->type);
 
       /* Validate and read payload. Content format from option must be
        * acceptable for resource value type. */
@@ -183,20 +136,20 @@ static void message_handler(struct coap_context_t *ctx, coap_session_t *session,
         case Edgex_Float64:
           /* data conversion requires a null terminated string */
           coap_resp_data = read_data_float64(data, len);
-          iot_log_info(sdk_ctx->lc, "COAP:coap float data=%s, len = %d", data,
-                       len);
+          iot_log_debug(sdk_ctx->lc, "COAP:coap float data=%s, len = %d", data,
+                        len);
           break;
 
         case Edgex_Int32:
-          iot_log_info(sdk_ctx->lc, "COAP:coap int32 data=%s, len = %d", data,
-                       len);
+          iot_log_debug(sdk_ctx->lc, "COAP:coap int32 data=%s, len = %d", data,
+                        len);
           coap_resp_data = read_data_int32(data, len);
           break;
 
         case Edgex_String:
           coap_resp_data = read_data_string(data, len);
-          iot_log_info(sdk_ctx->lc, "COAP:coap json data=%s, len = %d", data,
-                       len);
+          iot_log_debug(sdk_ctx->lc, "COAP:coap json data=%s, len = %d", data,
+                        len);
           break;
 
         default:
@@ -213,9 +166,34 @@ static void message_handler(struct coap_context_t *ctx, coap_session_t *session,
   }
 
 finish:
-  edgex_free_device(sdk_ctx->service, device);
+  if (device != NULL) {
+    edgex_free_device(sdk_ctx->service, (edgex_device *)device);
+  }
   coap_resp_rcvd = true;
 }
+/*
+Handling NACK messages for coap requests
+*/
+static void nack_handler(coap_context_t *context, coap_session_t *session,
+                         coap_pdu_t *sent, coap_nack_reason_t reason,
+                         const coap_tid_t id) {
+  coap_driver *sdk_ctx = (coap_driver *)impl;
+  switch (reason) {
+    case COAP_NACK_TOO_MANY_RETRIES:
+    case COAP_NACK_NOT_DELIVERABLE:
+    case COAP_NACK_RST:
+    case COAP_NACK_TLS_FAILED:
+    case COAP_NACK_ICMP_ISSUE:
+      coap_resp_rcvd = true;
+      iot_log_error(sdk_ctx->lc, "COAP:NACK response from server");
+      break;
+    default:
+      coap_resp_rcvd = true;
+      break;
+  }
+  return;
+}
+
 /*
 waits for coap response for CON request from end device
 */
@@ -231,14 +209,18 @@ static void WaitForCoapResponseFromEndDevice(coap_context_t *ctx,
     }
   }
 }
-
+/*
+send put request to end device
+*/
 int CoapSendCommandToEndDevice(uint8_t *data, size_t len, char *dev_name,
-                               char *resource_name) {
+                               char *resource_name,
+                               end_dev_params *end_dev_params_ptr,
+                               coap_driver *driver) {
   coap_context_t *ctx = NULL;
   coap_session_t *session = NULL;
   coap_address_t dst;
   coap_pdu_t *pdu = NULL;
-  sdk_ctx = impl;
+  coap_driver *sdk_ctx = (coap_driver *)driver;
   int result = EXIT_FAILURE;
   uint8_t *post_data = data;
   char uri[COAP_URI_MAXLEN + 1] = {0};
@@ -247,33 +229,33 @@ int CoapSendCommandToEndDevice(uint8_t *data, size_t len, char *dev_name,
   coap_proto_t proto = COAP_PROTO_UDP;
   char *port = "5683";
 
-  if (end_dev_params_instance.security_mode != SECURITY_MODE_NOSEC) {
+  if (end_dev_params_ptr->security_mode != SECURITY_MODE_NOSEC) {
     proto = COAP_PROTO_DTLS;
     port = "5684";
   }
 
-  if (resolve_address(end_dev_params_instance.end_dev_addr, port, &dst) < 0) {
+  if (resolve_address(end_dev_params_ptr->end_dev_addr, port, &dst) < 0) {
     coap_log(LOG_CRIT, "COAP:failed to resolve address\n");
     return result;
   }
-  iot_log_info(sdk_ctx->lc, "COAP: End dev addr = %s",
-               end_dev_params_instance.end_dev_addr);
+  iot_log_debug(sdk_ctx->lc, "COAP: End dev addr = %s",
+                end_dev_params_ptr->end_dev_addr);
 
-  iot_log_info(sdk_ctx->lc, "COAP: Data = %d, Len = %d", *post_data, len);
+  iot_log_debug(sdk_ctx->lc, "COAP: Data = %d, Len = %d", *post_data, len);
   /* create CoAP context and a client session */
   ctx = coap_new_context(NULL);
   if (ctx == NULL) {
     iot_log_error(sdk_ctx->lc, "COAP:coap new context creation failed\n");
     return result;
   }
-  if (end_dev_params_instance.security_mode == SECURITY_MODE_PSK) {
-    iot_log_info(sdk_ctx->lc, "COAP-client:ED psk key = %s, len=%d",
-                 (uint8_t *)end_dev_params_instance.psk_key,
-                 strlen(end_dev_params_instance.psk_key));
+  if (end_dev_params_ptr->security_mode == SECURITY_MODE_PSK) {
+    iot_log_debug(sdk_ctx->lc, "COAP-client:ED psk key = %s, len=%d",
+                  (uint8_t *)end_dev_params_ptr->psk_key,
+                  strlen(end_dev_params_ptr->psk_key));
     if (!ctx || !(session = coap_new_client_session_psk(
                       ctx, NULL, &dst, proto, "r17",
-                      (uint8_t *)(end_dev_params_instance.psk_key),
-                      strlen(end_dev_params_instance.psk_key)))) {
+                      (uint8_t *)(end_dev_params_ptr->psk_key),
+                      strlen(end_dev_params_ptr->psk_key)))) {
       iot_log_error(sdk_ctx->lc, "COAP:cannot initialize PSK");
       return result;
     }
@@ -284,6 +266,7 @@ int CoapSendCommandToEndDevice(uint8_t *data, size_t len, char *dev_name,
     }
   }
   coap_register_response_handler(ctx, message_handler);
+  coap_register_nack_handler(ctx, nack_handler);
 
   /* construct CoAP message */
   pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_PUT,
@@ -310,9 +293,6 @@ int CoapSendCommandToEndDevice(uint8_t *data, size_t len, char *dev_name,
 
     buf += coap_opt_size(buf);
   }
-
-  //  result = coap_add_option(pdu, COAP_OPTION_URI_PATH, strlen(uri),
-  //                           (const uint8_t *)(uri));
   if (result <= 0) {  // size
     result = EXIT_FAILURE;
     return result;
@@ -333,12 +313,14 @@ int CoapSendCommandToEndDevice(uint8_t *data, size_t len, char *dev_name,
 /*
 send coap get request to end device. waits for the response form end device.
 */
-int CoapGetRequestToEndDevice(char *dev_name, char *resource_name) {
+int CoapGetRequestToEndDevice(char *dev_name, char *resource_name,
+                              end_dev_params *end_dev_params_ptr,
+                              coap_driver *driver) {
   coap_context_t *ctx = NULL;
   coap_session_t *session = NULL;
   coap_address_t dst;
   coap_pdu_t *pdu = NULL;
-  sdk_ctx = impl;
+  coap_driver *sdk_ctx = (coap_driver *)driver;
   int result = EXIT_FAILURE;
   char uri[COAP_URI_MAXLEN + 1] = {0};
 
@@ -347,17 +329,17 @@ int CoapGetRequestToEndDevice(char *dev_name, char *resource_name) {
   coap_proto_t proto = COAP_PROTO_UDP;
   char *port = "5683";
 
-  if (end_dev_params_instance.security_mode != SECURITY_MODE_NOSEC) {
+  if (end_dev_params_ptr->security_mode != SECURITY_MODE_NOSEC) {
     proto = COAP_PROTO_DTLS;
     port = "5684";
   }
 
-  if (resolve_address(end_dev_params_instance.end_dev_addr, port, &dst) < 0) {
+  if (resolve_address(end_dev_params_ptr->end_dev_addr, port, &dst) < 0) {
     coap_log(LOG_CRIT, "COAP:failed to resolve address\n");
     return result;
   }
-  iot_log_info(sdk_ctx->lc, "COAP: End dev addr = %s",
-               end_dev_params_instance.end_dev_addr);
+  iot_log_debug(sdk_ctx->lc, "COAP: End dev addr = %s",
+                end_dev_params_ptr->end_dev_addr);
 
   /* create CoAP context and a client session */
   ctx = coap_new_context(NULL);
@@ -365,14 +347,14 @@ int CoapGetRequestToEndDevice(char *dev_name, char *resource_name) {
     iot_log_error(sdk_ctx->lc, "COAP:coap new context creation failed\n");
     return result;
   }
-  if (end_dev_params_instance.security_mode == SECURITY_MODE_PSK) {
-    iot_log_info(sdk_ctx->lc, "COAP-client:ED psk key = %s, len=%d",
-                 (uint8_t *)end_dev_params_instance.psk_key,
-                 strlen(end_dev_params_instance.psk_key));
+  if (end_dev_params_ptr->security_mode == SECURITY_MODE_PSK) {
+    iot_log_debug(sdk_ctx->lc, "COAP-client:ED psk key = %s, len=%d",
+                  (uint8_t *)end_dev_params_ptr->psk_key,
+                  strlen(end_dev_params_ptr->psk_key));
     if (!ctx || !(session = coap_new_client_session_psk(
                       ctx, NULL, &dst, proto, "r17",
-                      (uint8_t *)(end_dev_params_instance.psk_key),
-                      strlen(end_dev_params_instance.psk_key)))) {
+                      (uint8_t *)(end_dev_params_ptr->psk_key),
+                      strlen(end_dev_params_ptr->psk_key)))) {
       iot_log_error(sdk_ctx->lc, "COAP:cannot initialize PSK");
       return result;
     }
@@ -383,6 +365,7 @@ int CoapGetRequestToEndDevice(char *dev_name, char *resource_name) {
     }
   }
   coap_register_response_handler(ctx, message_handler);
+  coap_register_nack_handler(ctx, nack_handler);
 
   /* construct CoAP message */
   pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_GET,

--- a/src/c/coap-client.h
+++ b/src/c/coap-client.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020
+ * Ken Bannister
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _COAP_CLIENT_H_
+#define _COAP_CLIENT_H_ 1
+
+/**
+ * @file
+ * @brief Defines coap client artifacts for the CoAP device service.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define COAP_URI_MAXLEN \
+  32  // should be minimum of (sizeof("/a1r") + sizeof("/device-name") +
+      // sizeof("resource-name"))
+
+extern int CoapSendCommandToEndDevice(uint8_t *data, size_t len, char *dev_name,
+                                      char *resource_name);
+extern bool GetEndDeviceConfig(char *dev_name);
+extern int CoapGetRequestToEndDevice(char *dev_name, char *resource_name);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/c/coap-client.h
+++ b/src/c/coap-client.h
@@ -17,6 +17,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#include "device-coap.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,10 +27,23 @@ extern "C" {
   32  // should be minimum of (sizeof("/a1r") + sizeof("/device-name") +
       // sizeof("resource-name"))
 
+typedef struct {
+  char end_dev_addr[256];             // To hold IPv6 address
+  coap_security_mode_t security_mode; /**< CoAP transport security mode */
+  char psk_key[16];
+} end_dev_params;
+
+bool GetEndDeviceProtocolProperties(const devsdk_protocols *protocols,
+                                    char *protocol_name, iot_data_t **exception,
+                                    end_dev_params *end_dev_params_ptr,
+                                    coap_driver *driver);
 extern int CoapSendCommandToEndDevice(uint8_t *data, size_t len, char *dev_name,
-                                      char *resource_name);
-extern bool GetEndDeviceConfig(char *dev_name);
-extern int CoapGetRequestToEndDevice(char *dev_name, char *resource_name);
+                                      char *resource_name,
+                                      end_dev_params *end_dev_params_ptr,
+                                      coap_driver *driver);
+extern int CoapGetRequestToEndDevice(char *dev_name, char *resource_name,
+                                     end_dev_params *end_dev_params_ptr,
+                                     coap_driver *driver);
 #ifdef __cplusplus
 }
 #endif

--- a/src/c/coap-server.h
+++ b/src/c/coap-server.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020
+ * Ken Bannister
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _COAP_SERVER_H_
+#define _COAP_SERVER_H_ 1
+
+/**
+ * @file
+ * @brief Defines coap server artifacts for the CoAP device service.
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**
+ * Runs a CoAP server until a SIGINT or SIGTERM event.
+ *
+ * @return EXIT_SUCCESS on normal completion
+ * @return EXIT_FAILURE if unable to run server
+ */
+extern int run_server(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/c/coap-util.c
+++ b/src/c/coap-util.c
@@ -1,0 +1,229 @@
+/* CoAP utils for device-coap-c
+ *
+ * Copyright (C) 2018 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (c) 2020 Ken Bannister
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "coap-util.h"
+
+#include <errno.h>
+#include <netdb.h>
+
+#include "device-coap.h"
+static coap_driver *sdk_ctx;
+/*
+ * Builds libcoap address struct from host/port. Presently accepts only
+ * internet addresses.
+ */
+int resolve_address(const char *host, const char *service,
+                    coap_address_t *lib_addr) {
+  struct addrinfo *res, *ainfo;
+  struct addrinfo hints;
+  int error, len = -1;
+  sdk_ctx = impl;
+
+  memset(&hints, 0, sizeof(hints));
+  memset(lib_addr, 0, sizeof(*lib_addr));
+  hints.ai_socktype = SOCK_DGRAM;
+  hints.ai_family = AF_UNSPEC;
+
+  error = getaddrinfo(host, service, &hints, &res);
+
+  if (error != 0) {
+    iot_log_info(sdk_ctx->lc, "getaddrinfo: %s\n", gai_strerror(error));
+    return error;
+  }
+
+  for (ainfo = res; ainfo != NULL; ainfo = ainfo->ai_next) {
+    /* Logic here allows for future non-IP addresses, but we don't accept them
+     * yet. */
+    if (ainfo->ai_addrlen <= sizeof(lib_addr->addr)) {
+      switch (ainfo->ai_family) {
+        case AF_INET6:
+        case AF_INET:
+          len = lib_addr->size = ainfo->ai_addrlen;
+          memcpy(&lib_addr->addr.sa, ainfo->ai_addr, lib_addr->size);
+          goto finish;
+        default:;
+      }
+    }
+  }
+
+finish:
+  freeaddrinfo(res);
+  return len;
+}
+
+/* Caller must free returned iot_data_t */
+iot_data_t *read_data_float64(uint8_t *data, size_t len) {
+  sdk_ctx = impl;
+  if (len > FLOAT64_STR_MAXLEN) {
+    iot_log_info(sdk_ctx->lc, "invalid float64 of len %u", len);
+    return NULL;
+  }
+  /* data conversion requires a null terminated string */
+  uint8_t data_str[FLOAT64_STR_MAXLEN + 1];
+  data_str[len] = 0;
+  memcpy(data_str, data, len);
+
+  char *endptr;
+  errno = 0;
+  double dbl_val = strtod((char *)data_str, &endptr);
+
+  if (errno || (*endptr != '\0')) {
+    iot_log_info(sdk_ctx->lc, "invalid float64 of len %u", len);
+    return NULL;
+  }
+
+  return iot_data_alloc_f64(dbl_val);
+}
+
+/* Caller must free returned iot_data_t */
+iot_data_t *read_data_int32(uint8_t *data, size_t len) {
+  sdk_ctx = impl;
+  if (len > INT32_STR_MAXLEN) {
+    iot_log_info(sdk_ctx->lc, "invalid int32 of len %u", len);
+    return NULL;
+  }
+  /* data conversion requires a null terminated string */
+  uint8_t data_str[INT32_STR_MAXLEN + 1];
+  data_str[len] = 0;
+  memcpy(data_str, data, len);
+
+  char *endptr;
+  errno = 0;
+  long int_val = strtol((char *)data_str, &endptr, 10);
+
+  /* validate strtol conversion, and ensure within range */
+  if (errno || (*endptr != '\0') || (int_val < INT32_MIN) ||
+      (int_val > INT32_MAX)) {
+    iot_log_info(sdk_ctx->lc, "invalid int32 of len %u", len);
+    return NULL;
+  }
+
+  return iot_data_alloc_i32((int32_t)int_val);
+}
+
+/* Caller must free returned iot_data_t */
+iot_data_t *read_data_string(uint8_t *data, size_t len) {
+  /* must copy request data to append null terminator */
+  char *str_data = malloc(len + 1);
+  memcpy(str_data, data, len);
+  str_data[len] = '\0';
+
+  // iot_data_t *iot_data = iot_data_alloc_string(str_data, IOT_DATA_TAKE);
+  iot_data_t *iot_data = iot_data_alloc_string(str_data, IOT_DATA_COPY);
+  free(str_data);
+  return iot_data;
+}
+
+static size_t uri_decode(const char *src, const size_t len, char *dst) {
+  size_t i = 0, j = 0;
+  sdk_ctx = impl;
+  iot_log_debug(sdk_ctx->lc, "URI to decode = %s", src);
+  while (src[i] != '\0') {
+    int copy_char = 1;
+    if (src[i] == '%' && i + 2 < len) {
+      const unsigned char v1 = hexval[(unsigned char)src[i + 1]];
+      const unsigned char v2 = hexval[(unsigned char)src[i + 2]];
+
+      /* skip invalid hex sequences */
+      if ((v1 | v2) != 0xFF) {
+        dst[j] = (v1 << 4) | v2;
+        j++;
+        i += 3;
+        copy_char = 0;
+      }
+    }
+    if (copy_char) {
+      dst[j] = src[i];
+      i++;
+      j++;
+    }
+  }
+  dst[j] = '\0';
+  iot_log_debug(sdk_ctx->lc, "URI is decoded as= %s", dst);
+  return j;
+}
+
+/*
+ * Parse URI path, expect 3 segments: /a1r/{device-name}/{resource-name}
+ *
+ * @param[in] request For path to parse
+ * @param[out] device Found device
+ * @param[out] resource Found resource for device
+ * @return true if URI format OK, and device and resource found
+ */
+bool parse_path(coap_pdu_t *request, edgex_device **device_ptr,
+                edgex_deviceresource **resource_ptr) {
+  sdk_ctx = impl;
+  coap_string_t *uri_path = coap_get_uri_path(request);
+  iot_log_debug(sdk_ctx->lc, "URI %s", uri_path->s);
+  char path_tmp[32] = {0};
+  char path[32] = {0};
+  strcpy(path_tmp, (char *)uri_path->s);
+  iot_log_debug(sdk_ctx->lc, "URI %s", uri_path->s);
+  edgex_device *device = NULL;
+  edgex_deviceprofile *profile = NULL;
+  edgex_deviceresource *resource = NULL;
+  uri_decode(path_tmp, 16, path);
+  iot_log_debug(sdk_ctx->lc, "URI decode%s", path);
+  char *seg = strtok(path, "/");
+  bool res = false;
+  for (int i = 0; i < 3; i++) {
+    if (!seg) {
+      iot_log_info(sdk_ctx->lc, "missing URI segment %u", i);
+      break;
+    }
+
+    switch (i) {
+      case 0:
+        if (strcmp(seg, RESOURCE_SEG1)) {
+          iot_log_info(sdk_ctx->lc, "invalid URI; segment %u", i);
+          goto end_for;
+        }
+        break;
+      case 1:
+        if (!(device = edgex_get_device_byname(sdk_ctx->service, seg))) {
+          iot_log_info(sdk_ctx->lc, "device not found: %s", seg);
+          goto end_for;
+        }
+        profile = device->profile;
+        break;
+      case 2:
+        for (; profile; profile = profile->next) {
+          resource = profile->device_resources;
+          for (; resource; resource = resource->next) {
+            if (!strcmp(resource->name, seg)) {
+              break;
+            }
+          }
+        }
+        if (!resource) {
+          iot_log_info(sdk_ctx->lc, "resource not found: %s", seg);
+          goto end_for;
+        }
+        res = true;
+        break;
+    }
+    seg = strtok(NULL, "/");
+  }
+
+end_for:
+  if (res && seg) {
+    iot_log_info(sdk_ctx->lc, "extra URI segment");
+    res = false;
+  }
+  coap_delete_string(uri_path);
+
+  if (res) {
+    *device_ptr = device;
+    *resource_ptr = resource;
+  } else {
+    edgex_free_device(sdk_ctx->service, device);
+  }
+  return res;
+}
+

--- a/src/c/coap-util.h
+++ b/src/c/coap-util.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020
+ * Ken Bannister
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _COAP_UTIL_H_
+#define _COAP_UTIL_H_ 1
+
+/**
+ * @file
+ * @brief Defines common utils for the CoAP device service.
+ */
+
+#include <coap2/coap.h>
+#include <devsdk/devsdk.h>
+#include <edgex/devices.h>
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RESOURCE_SEG1 "a1r"
+/* Maximum length of a string containing numeric values. */
+#define FLOAT64_STR_MAXLEN 24
+#define INT32_STR_MAXLEN 11
+
+// to decode coap encoded uri in coap client message handler
+#define __ 0xFF
+static const unsigned char hexval[0x100] = {
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  __, __, __, __, __, __, /* 30-3F */
+    __, 10, 11, 12, 13, 14, 15, __, __, __, __, __, __, __, __, __, /* 40-4F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, 10, 11, 12, 13, 14, 15, __, __, __, __, __, __, __, __, __, /* 60-6F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, /* 00-0F */
+};
+
+extern int resolve_address(const char *host, const char *service,
+                           coap_address_t *lib_addr);
+extern iot_data_t *read_data_float64(uint8_t *data, size_t len);
+extern iot_data_t *read_data_int32(uint8_t *data, size_t len);
+extern iot_data_t *read_data_string(uint8_t *data, size_t len);
+extern bool parse_path(coap_pdu_t *request, edgex_device **device_ptr,
+                       edgex_deviceresource **resource_ptr);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/c/device-coap.c
+++ b/src/c/device-coap.c
@@ -1,5 +1,5 @@
-/* Entry point for an EdgeX device service that provides a CoAP server to receive
- * values asynchronously.
+/* Entry point for an EdgeX device service that provides a CoAP server to
+ * receive values asynchronously.
  *
  * Copyright (c) 2020
  * Ken Bannister
@@ -7,76 +7,67 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <unistd.h>
-#include <stdarg.h>
-
-#include "devsdk/devsdk.h"
 #include "device-coap.h"
+
+#include <stdarg.h>
+#include <unistd.h>
+
 #include "coap-client.h"
 #include "coap-server.h"
 #include "coap-util.h"
-#define ERR_CHECK(x) if (x.code) { fprintf (stderr, "Error: %d: %s\n", x.code, x.reason); devsdk_service_free (service); free (impl); return x.code; }
+#include "devsdk/devsdk.h"
+#define ERR_CHECK(x)                                      \
+  if (x.code) {                                           \
+    fprintf(stderr, "Error: %d: %s\n", x.code, x.reason); \
+    devsdk_service_free(service);                         \
+    free(impl);                                           \
+    return x.code;                                        \
+  }
 
 #define COAP_BIND_ADDR_KEY "CoapBindAddr"
-#define SECURITY_MODE_KEY  "SecurityMode"
-#define PSK_KEY_KEY        "PskKey"
+#define SECURITY_MODE_KEY "SecurityMode"
+#define PSK_KEY_KEY "PskKey"
 
-coap_driver
-    *impl;  // Used to access device service specific data in other modules
+coap_driver *impl;
 extern iot_data_t *coap_resp_data;
 
 /* Looks up security mode enum value from configuration text value */
-coap_security_mode_t find_security_mode
-(
-  const char *mode_text
-)
-{
-  assert (mode_text);
-  if (!strcmp (mode_text, "PSK"))
-  {
+coap_security_mode_t find_security_mode(const char *mode_text) {
+  assert(mode_text);
+  if (!strcmp(mode_text, "PSK")) {
     return SECURITY_MODE_PSK;
-  }
-  else if (!strcmp (mode_text, "NoSec"))
-  {
+  } else if (!strcmp(mode_text, "NoSec")) {
     return SECURITY_MODE_NOSEC;
-  }
-  else
-  {
+  } else {
     return SECURITY_MODE_UNKNOWN;
   }
 }
 
 /* Init callback; reads in config values to device driver */
-static bool coap_init
-(
-  void *impl,
-  struct iot_logger_t *lc,
-  const iot_data_t *config
-)
-{
-  coap_driver *driver = (coap_driver *) impl;
+static bool coap_init(void *impl, struct iot_logger_t *lc,
+                      const iot_data_t *config) {
+  coap_driver *driver = (coap_driver *)impl;
 
   driver->lc = lc;
-  driver->security_mode = find_security_mode (iot_data_string_map_get_string (config, SECURITY_MODE_KEY));
+  pthread_mutex_init(&driver->mutex, NULL);
+  driver->security_mode = find_security_mode(
+      iot_data_string_map_get_string(config, SECURITY_MODE_KEY));
 
   switch (driver->security_mode) {
     case SECURITY_MODE_UNKNOWN:
-      iot_log_error (lc, "Unknown security mode");
+      iot_log_error(lc, "Unknown security mode");
       driver->psk_key = NULL;
       return false;
 
-    case SECURITY_MODE_PSK:
-    {
-      const char *conf_psk_key = iot_data_string_map_get_string (config, PSK_KEY_KEY);
-      if (strlen (conf_psk_key))
-      {
-        iot_data_t *key_array = iot_data_alloc_array_from_base64 (conf_psk_key);
+    case SECURITY_MODE_PSK: {
+      const char *conf_psk_key =
+          iot_data_string_map_get_string(config, PSK_KEY_KEY);
+      if (strlen(conf_psk_key)) {
+        iot_data_t *key_array = iot_data_alloc_array_from_base64(conf_psk_key);
         driver->psk_key = key_array;
-        iot_log_info (lc, "PSK key len %u", iot_data_array_length (key_array));
-      }
-      else
-      {
-        iot_log_error (lc, "PSK key not in configuration");
+        iot_log_info(lc, "PSK key len %u", iot_data_array_length(key_array));
+      } else {
+        iot_log_error(lc, "PSK key not in configuration");
         driver->psk_key = NULL;
         return false;
       }
@@ -87,19 +78,17 @@ static bool coap_init
   }
 
   /* CoAP server bind address as text */
-  const char *bind_addr = iot_data_string_map_get_string (config, COAP_BIND_ADDR_KEY);
-  if (bind_addr)
-  {
-    driver->coap_bind_addr = iot_data_alloc_string (bind_addr, IOT_DATA_COPY);
-  }
-  else
-  {
-    iot_log_error (lc, "CoAP bind address not in configuration");
+  const char *bind_addr =
+      iot_data_string_map_get_string(config, COAP_BIND_ADDR_KEY);
+  if (bind_addr) {
+    driver->coap_bind_addr = iot_data_alloc_string(bind_addr, IOT_DATA_COPY);
+  } else {
+    iot_log_error(lc, "CoAP bind address not in configuration");
     driver->coap_bind_addr = NULL;
     return false;
   }
 
-  iot_log_debug (lc, "Init complete");
+  iot_log_debug(lc, "Init complete");
   return true;
 }
 
@@ -109,48 +98,43 @@ static bool coap_get_handler(void *impl, const devsdk_device_t *device,
                              devsdk_commandresult *readings,
                              const iot_data_t *options,
                              iot_data_t **exception) {
-  bool successful_get_request = true;
   coap_driver *driver = (coap_driver *)impl;
+  pthread_mutex_lock(&driver->mutex);
+  bool successful_get_request = true;
   int ret = EXIT_FAILURE;
   uint32_t i = 0;
-
   if (device == NULL) {
     iot_log_error(driver->lc, "COAP:Device is empty");
     return successful_get_request;
   }
-  successful_get_request = GetEndDeviceConfig(device->name);
-  if (successful_get_request != true) {
-    iot_log_error(driver->lc, "COAP:GetEndDeviceConfig failed");
-    return successful_get_request;
-  }
-
-  iot_log_debug(driver->lc, "COAP:Triggering auto events nreadings=%d\n",
+  end_dev_params *end_dev_params_ptr = (end_dev_params *)device->address;
+  iot_log_debug(driver->lc, "COAP:Triggering Get events nreadings=%d\n",
                 nreadings);
   /* The following requests and reading parameters are arrays of size nreadings
    */
   for (i = 0; i < nreadings; i++) {
-    iot_log_debug(driver->lc, "COAP:Triggering auto events resource name=%s\n",
+    iot_log_debug(driver->lc, "COAP:Triggering Get events resource name=%s\n",
                   requests[i].resource->name);
-    iot_log_debug(driver->lc, "COAP:Triggering auto events req type=%d\n",
+    iot_log_debug(driver->lc, "COAP:Triggering Get events req type=%d\n",
                   requests[i].resource->type);
-    ret = CoapGetRequestToEndDevice(device->name, requests[i].resource->name);
+    ret = CoapGetRequestToEndDevice(device->name, requests[i].resource->name,
+                                    end_dev_params_ptr, driver);
     if (ret == EXIT_FAILURE) {
       iot_log_error(driver->lc,
-                    "COAP:Triggering auto events failed with ret=%d\n", ret);
+                    "COAP:Triggering Get events failed with ret=%d\n", ret);
       successful_get_request = false;
     } else {
-      if(coap_resp_data != NULL) {
-      readings[i].origin = 0;
-      readings[i].value = coap_resp_data;
-      iot_log_debug(driver->lc,
-                    "COAP:Triggering auto events success with ret=%d\n", ret);
+      if (coap_resp_data != NULL) {
+        readings[i].origin = 0;
+        readings[i].value = coap_resp_data;
+        iot_log_debug(driver->lc,
+                      "COAP:Triggering Get events success with ret=%d\n", ret);
       } else {
-          successful_get_request = false;
+        successful_get_request = false;
       }
     }
   }
-  // iot_data_free(coap_resp_data);
-
+  pthread_mutex_unlock(&driver->mutex);
   return successful_get_request;
 }
 
@@ -163,17 +147,15 @@ static bool coap_put_handler(void *impl, const devsdk_device_t *device,
   (void)requests;
 
   coap_driver *driver = (coap_driver *)impl;
+  pthread_mutex_lock(&driver->mutex);
   int len = 0;
   int ret = EXIT_SUCCESS;
   bool successful_get_request = true;
   char coap_put_data[FLOAT64_STR_MAXLEN + 1] = {0};
   char *coap_str_data = NULL;
-  successful_get_request = GetEndDeviceConfig(device->name);
-  if (successful_get_request != true) {
-    iot_log_error(driver->lc, "COAP:GetEndDeviceConfig failed");
-    return successful_get_request;
-  }
+  end_dev_params *end_dev_params_ptr = (end_dev_params *)device->address;
   iot_log_debug(driver->lc, "COAP:PUT on device:");
+  iot_log_debug(driver->lc, "COAP: nvalues = %d", nvalues);
 
   for (uint32_t i = 0; i < nvalues; i++) {
     memset(coap_put_data, 0, FLOAT64_STR_MAXLEN + 1);
@@ -181,7 +163,8 @@ static bool coap_put_handler(void *impl, const devsdk_device_t *device,
       case Edgex_String: {
         coap_str_data = malloc(strlen(iot_data_string(values[i])) + 1);
         iot_log_debug(driver->lc, "  Value: %s", iot_data_string(values[i]));
-        memcpy(coap_str_data, iot_data_string(values[i]), strlen(iot_data_string(values[i])) + 1);
+        memcpy(coap_str_data, iot_data_string(values[i]),
+               strlen(iot_data_string(values[i])) + 1);
         len = strlen(coap_str_data);
         break;
       }
@@ -208,109 +191,119 @@ static bool coap_put_handler(void *impl, const devsdk_device_t *device,
       return false;
     }
 
-    if(iot_data_type(values[i]) == IOT_DATA_STRING) {
+    if (iot_data_type(values[i]) == IOT_DATA_STRING) {
       ret = CoapSendCommandToEndDevice((uint8_t *)coap_str_data, len,
-                                     device->name, requests[i].resource->name);
-      free (coap_str_data);
+                                       device->name, requests[i].resource->name,
+                                       end_dev_params_ptr, driver);
+      free(coap_str_data);
     } else {
       ret = CoapSendCommandToEndDevice((uint8_t *)coap_put_data, len,
-                                     device->name, requests[i].resource->name);
+                                       device->name, requests[i].resource->name,
+                                       end_dev_params_ptr, driver);
     }
     if (ret == -1) {
       iot_log_error(driver->lc, "Sending data to End Device fails=%d\n", ret);
       return false;
     }
-
-    return true;
+    successful_get_request = true;
   }
+  pthread_mutex_unlock(&driver->mutex);
   return successful_get_request;
 }
 
-
-static void coap_stop (void *impl, bool force) {}
-
-static devsdk_address_t coap_create_address (void *impl, const devsdk_protocols *protocols, iot_data_t **exception)
-{
-  return (devsdk_address_t)protocols;
+static void coap_stop(void *impl, bool force) {
+  coap_driver *driver = (coap_driver *)impl;
+  pthread_mutex_destroy(&driver->mutex);
 }
 
-static void coap_free_address (void *impl, devsdk_address_t address)
-{
+static devsdk_address_t coap_create_address(void *impl,
+                                            const devsdk_protocols *protocols,
+                                            iot_data_t **exception) {
+  bool res = false;
+  coap_driver *driver = (coap_driver *)impl;
+  end_dev_params *end_dev_params_ptr =
+      (end_dev_params *)malloc(sizeof(end_dev_params));
+  if (end_dev_params_ptr != NULL) {
+    res = GetEndDeviceProtocolProperties(
+        protocols, "COAP", exception, end_dev_params_ptr, (coap_driver *)impl);
+    if (res == false) {
+      iot_log_error(driver->lc, "COAP: protocol property for device is null");
+    }
+  }
+  return (devsdk_address_t)end_dev_params_ptr;
 }
 
-static devsdk_resource_attr_t coap_create_resource_attr (void *impl, const iot_data_t *attributes, iot_data_t **exception)
-{
+static void coap_free_address(void *impl, devsdk_address_t address) {
+  coap_driver *driver = (coap_driver *)impl;
+  if (address != NULL) {
+    free(address);
+  } else {
+    iot_log_error(driver->lc, "COAP: protocol address for device is null");
+  }
+}
+
+static devsdk_resource_attr_t coap_create_resource_attr(
+    void *impl, const iot_data_t *attributes, iot_data_t **exception) {
   return (devsdk_resource_attr_t)attributes;
 }
 
-static void coap_free_resource_attr (void *impl, devsdk_resource_attr_t attr)
-{
-}
+static void coap_free_resource_attr(void *impl, devsdk_resource_attr_t attr) {}
 
-int main (int argc, char *argv[])
-{
-  impl = malloc (sizeof (coap_driver));
-  memset (impl, 0, sizeof (coap_driver));
+int main(int argc, char *argv[]) {
+  impl = malloc(sizeof(coap_driver));
+  memset(impl, 0, sizeof(coap_driver));
 
   devsdk_error e;
   e.code = 0;
 
   /* Device Callbacks */
-  devsdk_callbacks *coapImpls = devsdk_callbacks_init
-  (
-    coap_init,
-    coap_get_handler,
-    coap_put_handler,
-    coap_stop,
-    coap_create_address,
-    coap_free_address,
-    coap_create_resource_attr,
-    coap_free_resource_attr
-  );
+  devsdk_callbacks *coapImpls =
+      devsdk_callbacks_init(coap_init, coap_get_handler, coap_put_handler,
+                            coap_stop, coap_create_address, coap_free_address,
+                            coap_create_resource_attr, coap_free_resource_attr);
 
   /* Initialize a new device service */
-  devsdk_service_t *service = devsdk_service_new
-    ("device-coap", VERSION, impl, coapImpls, &argc, argv, &e);
-  ERR_CHECK (e);
+  devsdk_service_t *service = devsdk_service_new("device-coap", VERSION, impl,
+                                                 coapImpls, &argc, argv, &e);
+  ERR_CHECK(e);
   impl->service = service;
 
   int n = 1;
-  while (n < argc)
-  {
-    if (strcmp (argv[n], "-h") == 0 || strcmp (argv[n], "--help") == 0)
-    {
-      printf ("Options:\n");
-      printf ("  -h, --help\t\t\tShow this text\n");
-      devsdk_usage ();
+  while (n < argc) {
+    if (strcmp(argv[n], "-h") == 0 || strcmp(argv[n], "--help") == 0) {
+      printf("Options:\n");
+      printf("  -h, --help\t\t\tShow this text\n");
+      devsdk_usage();
       return 0;
-    }
-    else
-    {
-      printf ("%s: Unrecognized option %s\n", argv[0], argv[n]);
+    } else {
+      printf("%s: Unrecognized option %s\n", argv[0], argv[n]);
       return 0;
     }
   }
 
   /* Create default Driver config and start the device service */
-  iot_data_t *driver_map = iot_data_alloc_map (IOT_DATA_STRING);
-  iot_data_string_map_add (driver_map, COAP_BIND_ADDR_KEY, iot_data_alloc_string ("0.0.0.0", IOT_DATA_REF));
-  iot_data_string_map_add (driver_map, SECURITY_MODE_KEY, iot_data_alloc_string ("NoSec", IOT_DATA_REF));
-  iot_data_string_map_add (driver_map, PSK_KEY_KEY, iot_data_alloc_string ("", IOT_DATA_REF));
+  iot_data_t *driver_map = iot_data_alloc_map(IOT_DATA_STRING);
+  iot_data_string_map_add(driver_map, COAP_BIND_ADDR_KEY,
+                          iot_data_alloc_string("0.0.0.0", IOT_DATA_REF));
+  iot_data_string_map_add(driver_map, SECURITY_MODE_KEY,
+                          iot_data_alloc_string("NoSec", IOT_DATA_REF));
+  iot_data_string_map_add(driver_map, PSK_KEY_KEY,
+                          iot_data_alloc_string("", IOT_DATA_REF));
 
-  devsdk_service_start (service, driver_map, &e);
-  ERR_CHECK (e);
+  devsdk_service_start(service, driver_map, &e);
+  ERR_CHECK(e);
 
   /* Run CoAP server */
   run_server();
 
-  devsdk_service_stop (service, true, &e);
-  ERR_CHECK (e);
+  devsdk_service_stop(service, true, &e);
+  ERR_CHECK(e);
 
-  devsdk_service_free (service);
-  iot_data_free (driver_map);
-  iot_data_free (impl->coap_bind_addr);
-  iot_data_free (impl->psk_key);
-  free (impl);
-  puts ("Exiting gracefully");
+  devsdk_service_free(service);
+  iot_data_free(driver_map);
+  iot_data_free(impl->coap_bind_addr);
+  iot_data_free(impl->psk_key);
+  free(impl);
+  puts("Exiting gracefully");
   return 0;
 }

--- a/src/c/device-coap.h
+++ b/src/c/device-coap.h
@@ -37,6 +37,7 @@ typedef struct coap_driver {
   iot_data_t *coap_bind_addr; /**< Address server binds to, for incoming data */
   coap_security_mode_t security_mode; /**< CoAP transport security mode */
   iot_data_t *psk_key; /**< PSK key as uint8_t array; unused if not PSK mode */
+  pthread_mutex_t mutex; //for synchronization
 } coap_driver;
 
 extern coap_driver *impl;

--- a/src/c/device-coap.h
+++ b/src/c/device-coap.h
@@ -14,43 +14,33 @@
  * @brief Defines common artifacts for the CoAP device service.
  */
 
-#include "devsdk/devsdk.h"
-
+#include <devsdk/devsdk.h>
+#include <edgex/devices.h>
+#include <stdlib.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** CoAP messaging transport security mode */
-typedef enum
-{
-  SECURITY_MODE_PSK,        /**< pre-shared key */
-  SECURITY_MODE_NOSEC,      /**< no security */
-  SECURITY_MODE_UNKNOWN     /**< not a security mode; just means mode not known */
+typedef enum {
+  SECURITY_MODE_PSK,    /**< pre-shared key */
+  SECURITY_MODE_NOSEC,  /**< no security */
+  SECURITY_MODE_UNKNOWN /**< not a security mode; just means mode not known */
 } coap_security_mode_t;
-
 
 /**
  * device-coap-c specific data included with service callbacks
  */
-typedef struct coap_driver
-{
-  iot_logger_t * lc;
+typedef struct coap_driver {
+  iot_logger_t *lc;
   devsdk_service_t *service;
-  iot_data_t *coap_bind_addr;           /**< Address server binds to, for incoming data */
-  coap_security_mode_t security_mode;   /**< CoAP transport security mode */
-  iot_data_t *psk_key;                  /**< PSK key as uint8_t array; unused if not PSK mode */
+  iot_data_t *coap_bind_addr; /**< Address server binds to, for incoming data */
+  coap_security_mode_t security_mode; /**< CoAP transport security mode */
+  iot_data_t *psk_key; /**< PSK key as uint8_t array; unused if not PSK mode */
 } coap_driver;
 
-/**
- * Runs a CoAP server until a SIGINT or SIGTERM event.
- *
- * @param driver   EdgeX driver
- * @return EXIT_SUCCESS on normal completion
- * @return EXIT_FAILURE if unable to run server
- */
-int run_server(coap_driver *driver);
-
-
+extern coap_driver *impl;
+extern coap_security_mode_t find_security_mode(const char *mode_text);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-coap-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-coap-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
I have not added any unit test cases, I have done functional testing.
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>
 It is a new feature update
## Testing Instructions
<!-- How can the reviewers test your change? -->
Test setup is mentioned in README file.
Total 6 test cases are tested.
1. Auto events for `int` resource
2. Auto events for `float` resource
3. Auto events for `json` resource
4. Put request to `int` resource
5. Put request to `float` resource
6. Put request to `json` resource  

Test case inputs used for functionality testing are mentioned in below table
<html>
<body>
<!--StartFragment--><!DOCTYPE html><figure class="md-table-fig" cid="n2" mdtype="table" style="box-sizing: border-box; margin: 1.2em 0px; overflow-x: auto; max-width: calc(100% + 16px); padding: 0px; cursor: default; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

Test case  No | datatype | PSK set in devices.json | Get/Set data at  End device | Put data from EdgeX
-- | -- | -- | -- | --
1 | Int | No PSK | 9876 | {"int":"1234"}
2   |   Int   | hello123 | 9876 | {"int":"1234"} |   |  
3 | Float | No PSK | 1.2345 | {"float":"9.8765"}
4 |  Float  | hello456 | 1.2345 | {"float":"9.8765"} |   |  
5 | Json | No PSK | {JsonKey:JsonValue} | {"json":"{JsonKey:JsonValue}"}
6 | Json  | hello789 | {JsonKey:JsonValue} | {"json":"{JsonKey:JsonValue}"} |   |  

</figure><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>
 
All the above 6 test cases are passed.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->