### PR TITLE
feat: use secret store for PSK key (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ For example if using insecure mode (secrets in configuration file):
 
 ```
   [Writable.InsecureSecrets]
-    [Writable.InsecureSecrets.device-coap]
-      path = "device-coap"
-      [Writable.InsecureSecrets.device-coap.Secrets]
+    [Writable.InsecureSecrets.psk]
+      path = "psk"
+      [Writable.InsecureSecrets.psk.Secrets]
         # Key is up to 16 arbitrary bytes; must be base64 encoded here
         PskKey = 'ME42aURHZ3Uva0Y0eG9lZw=='
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Below are the recognized properties for the Driver section, followed by an examp
 |-------------|-----------------------------------------------------------------------------------|
 | CoapBindAddr| Address on which CoAP server listens for devices                                  |
 | SecurityMode| DTLS client-server security type. Does not support raw public key or certificates.|
-| PskKey      | Pre-shared key. Accepts only a single key, ignored in NoSec mode.                 |
 
 
 ```
@@ -64,8 +63,24 @@ Below are the recognized properties for the Driver section, followed by an examp
   CoapBindAddr = '0.0.0.0'
   # Choose 'PSK' or 'NoSec'
   SecurityMode = 'PSK'
-  # Key is up to 16 arbitrary bytes; must be base64 encoded here
-  PskKey = 'ME42aURHZ3Uva0Y0eG9lZw=='
+```
+
+### Secrets
+
+If configured for PSK mode, a key must be stored in the service's secret store:
+| Secret name | Value                                                                             |
+|-------------|-----------------------------------------------------------------------------------|
+| PskKey      | Pre-shared key. Accepts only a single key, ignored in NoSec mode.                 |
+
+For example if using insecure mode (secrets in configuration file):
+
+```
+  [Writable.InsecureSecrets]
+    [Writable.InsecureSecrets.device-coap]
+      path = "device-coap"
+      [Writable.InsecureSecrets.device-coap.Secrets]
+        # Key is up to 16 arbitrary bytes; must be base64 encoded here
+        PskKey = 'ME42aURHZ3Uva0Y0eG9lZw=='
 ```
 
 ## Devices

--- a/res/configuration-native.toml
+++ b/res/configuration-native.toml
@@ -53,8 +53,20 @@
     [Writable.Device.Discovery]
     Enabled = false
   [Writable.InsecureSecrets]
-    [Writable.InsecureSecrets.device-coap]
-      path = "device-coap"
-      [Writable.InsecureSecrets.device-coap.Secrets]
+    [Writable.InsecureSecrets.psk]
+      path = "psk"
+      [Writable.InsecureSecrets.psk.Secrets]
         # Key is up to 16 arbitrary bytes; must be base64 encoded here
         PskKey = "ME42aURHZ3Uva0Y0eG9lZw=="
+
+[SecretStore]
+Type = "vault"
+Protocol = "http"
+Host = "localhost"
+Port = 8200
+Path = "device-coap/"
+TokenFile = "/tmp/edgex/secrets/device-coap/secrets-token.json"
+RootCaCertPath = ""
+ServerName = ""
+  [SecretStore.Authentication]
+  AuthType = "X-Vault-Token"

--- a/res/configuration-native.toml
+++ b/res/configuration-native.toml
@@ -32,8 +32,7 @@
   CoapBindAddr = "0.0.0.0"
   # Choose "PSK" or "NoSec"
   SecurityMode = "NoSec"
-  # Key is up to 16 arbitrary bytes; must be base64 encoded here
-  PskKey = "ME42aURHZ3Uva0Y0eG9lZw=="
+  # PSK key is in the Secrets section below
 
 [MessageQueue]
   Protocol = "redis"
@@ -53,3 +52,9 @@
     UpdateLastConnected = false
     [Writable.Device.Discovery]
     Enabled = false
+  [Writable.InsecureSecrets]
+    [Writable.InsecureSecrets.device-coap]
+      path = "device-coap"
+      [Writable.InsecureSecrets.device-coap.Secrets]
+        # Key is up to 16 arbitrary bytes; must be base64 encoded here
+        PskKey = "ME42aURHZ3Uva0Y0eG9lZw=="

--- a/res/configuration.toml
+++ b/res/configuration.toml
@@ -52,8 +52,20 @@
     [Writable.Device.Discovery]
     Enabled = false
   [Writable.InsecureSecrets]
-    [Writable.InsecureSecrets.device-coap]
-      path = "device-coap"
-      [Writable.InsecureSecrets.device-coap.Secrets]
+    [Writable.InsecureSecrets.psk]
+      path = "psk"
+      [Writable.InsecureSecrets.psk.Secrets]
         # Key is up to 16 arbitrary bytes; must be base64 encoded here
         PskKey = "ME42aURHZ3Uva0Y0eG9lZw=="
+
+[SecretStore]
+Type = "vault"
+Protocol = "http"
+Host = "localhost"
+Port = 8200
+Path = "device-coap/"
+TokenFile = "/tmp/edgex/secrets/device-coap/secrets-token.json"
+RootCaCertPath = ""
+ServerName = ""
+  [SecretStore.Authentication]
+  AuthType = "X-Vault-Token"

--- a/res/configuration.toml
+++ b/res/configuration.toml
@@ -31,8 +31,7 @@
   CoapBindAddr = "0.0.0.0"
   # Choose "PSK" or "NoSec"
   SecurityMode = "PSK"
-  # Key is up to 16 arbitrary bytes; must be base64 encoded here
-  PskKey = "ME42aURHZ3Uva0Y0eG9lZw=="
+  # PSK key is in the Secrets section below
 
 [MessageQueue]
   Protocol = "redis"
@@ -52,3 +51,9 @@
     UpdateLastConnected = false
     [Writable.Device.Discovery]
     Enabled = false
+  [Writable.InsecureSecrets]
+    [Writable.InsecureSecrets.device-coap]
+      path = "device-coap"
+      [Writable.InsecureSecrets.device-coap.Secrets]
+        # Key is up to 16 arbitrary bytes; must be base64 encoded here
+        PskKey = "ME42aURHZ3Uva0Y0eG9lZw=="

--- a/src/c/device-coap.c
+++ b/src/c/device-coap.c
@@ -64,7 +64,7 @@ static bool coap_init(void *impl, struct iot_logger_t *lc,
     }
 
     case SECURITY_MODE_PSK: {
-      iot_data_t *secrets = devsdk_get_secrets (driver->service, "device-coap");
+      iot_data_t *secrets = devsdk_get_secrets (driver->service, "psk");
       const char *conf_psk_key =
           iot_data_string_map_get_string(secrets, PSK_KEY_KEY);
       if (!conf_psk_key) {


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-coap-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-coap-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) - no unit tests for C device services
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - documentation updated in this PR
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run the service in PSK mode with a simulated device (see "Testing/Simulation for CoAP Server" in the README
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->