### PR TITLE
ci: Use standard container name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ device_coap:
 	    docker build \
 	        -f scripts/Dockerfile.alpine \
 	        --label "git_sha=$(GIT_SHA)" \
-	        -t edgexfoundry/docker-device-coap-c:${GIT_SHA} \
-	        -t edgexfoundry/docker-device-coap-c:${VERSION}-dev \
+	        -t edgexfoundry/device-coap:${GIT_SHA} \
+	        -t edgexfoundry/device-coap:${VERSION}-dev \
             .
 
 build-debug: build/debug/device-coap


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-coap-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-coap-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)   *ci change only*
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) *ci change only*
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->